### PR TITLE
Adding save and load methods to the new classification api

### DIFF
--- a/discoverx/discovery.py
+++ b/discoverx/discovery.py
@@ -57,6 +57,20 @@ class Discovery:
             logger.debug(f"Executing SQL:\n{sql_rows}")
             return msql_builder.execute_sql_rows(sql_rows, self.spark)
 
+    def save(self, full_table_name: str):
+        """Saves the scan results to the lakehouse
+
+        Args:
+            full_table_name (str): The full table name to be
+                used to save the scan results.
+        Raises:
+            Exception: If the scan has not been run
+
+        """
+        self._check_scan_result()
+        # save classes
+        self._scan_result.save(full_table_name)
+
     def scan(
         self,
         rules="*",

--- a/discoverx/dx.py
+++ b/discoverx/dx.py
@@ -2,6 +2,7 @@ import pandas as pd
 from pyspark.sql import SparkSession
 from typing import List, Optional, Union
 from discoverx import logging
+from discoverx.discovery import Discovery
 from discoverx.explorer import DataExplorer, InfoFetcher
 from discoverx.msql import Msql
 from discoverx.rules import Rules, Rule
@@ -184,6 +185,30 @@ class DX:
         """
         self._scan_result = ScanResult(df=pd.DataFrame(), spark=self.spark)
         self._scan_result.load(full_table_name)
+
+    def load_classification(self, full_table_name: str):
+        """Loads previously saved classification results from a table
+
+        Args:
+            full_table_name (str, optional): The full table name to be
+                used to load the classification results.
+        Raises:
+            Exception: If the table to be loaded does not exist
+        """
+        scan_result = ScanResult(df=pd.DataFrame(), spark=self.spark)
+        scan_result.load_classification(full_table_name)
+        discover = Discovery(
+            self.spark,
+            scan_result.catalogs,
+            scan_result.schemas,
+            scan_result.tables,
+            InfoFetcher(self.spark, self.COLUMNS_TABLE_NAME).get_tables_info(
+                scan_result.catalogs, scan_result.schemas, scan_result.tables, columns=[]
+            ),  # TODO: Need to add column support, i.e. include having_columns functionality
+        )
+        discover._scan_result = scan_result # TODO: Move the loading of the scan result into Discover or ScanResult class
+        return discover
+
 
     def search(
         self,


### PR DESCRIPTION
We recently added scan() to the new api, i.e. dx.from_tables().scan(). We have not added support for persisting the scan result and loading it back again for this new api so users would still rely on the dx.scan() methods instead. This PR is about adding the missing functionality to the new api.