### PR TITLE
Add Makefile common actions to make contributing easier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: clean dev test
+
+clean:
+	rm -fr .venv clean htmlcov .mypy_cache .pytest_cache .ruff_cache .coverage coverage.xml
+	rm -fr **/*.pyc
+
+dev:
+	pip install -e ".[local,test]"
+
+
+test:
+	pytest tests/unit --cov


### PR DESCRIPTION
Add little short cuts to contributing.
`make clean` # clean up build products
`make dev` # install dev and local dependencies
`make test` # run unit tests

